### PR TITLE
曲のソート順を変更

### DIFF
--- a/lib/SongAPI.ts
+++ b/lib/SongAPI.ts
@@ -52,8 +52,8 @@ const fetchPopularSongsByYear = async (year: number, limit: number = 3): Promise
       rank <= ${limit}
     ORDER BY
       articles_cnt DESC,
-      artist_name,
-      song_name
+      song_name,
+      artist_name
   `;
 
   return rows.map(row => ({


### PR DESCRIPTION
#8 で曲を探しやすくするためにソート順を変更したが #27 で検索機能を実装したので従来の直感的なソート順に戻す。